### PR TITLE
Sliding expiration

### DIFF
--- a/dist/util/file-storage.js
+++ b/dist/util/file-storage.js
@@ -78,13 +78,20 @@ var FileStorage = function () {
 				});
 			});
 		}
+
+		/**
+   * Resets file expiration. It changes LastModified file property.
+   * Please PAY ATTENTION, it clears all metadata values, except ContentType
+   */
+
 	}, {
 		key: 'resetFileExpiration',
 		value: function resetFileExpiration(key) {
 			return this.s3.copyObjectAsync({
 				Bucket: this.bucket,
 				CopySource: this.bucket + '/' + key,
-				Key: key
+				Key: key,
+				MetadataDirective: 'REPLACE'
 			});
 		}
 	}, {

--- a/dist/util/file-storage.js
+++ b/dist/util/file-storage.js
@@ -66,26 +66,24 @@ var FileStorage = function () {
 
 	_createClass(FileStorage, [{
 		key: 'putFile',
-		value: function putFile(key, filename, expiration) {
+		value: function putFile(key, filename) {
 			var _this = this;
 
 			return openReadStream(filename).then(function (stream) {
 				return _this.s3.putObjectAsync({
 					Bucket: _this.bucket,
 					Key: key,
-					Body: stream,
-					Expires: new Date(expiration)
+					Body: stream
 				});
 			});
 		}
 	}, {
-		key: 'setFileExpiration',
-		value: function setFileExpiration(key, expiration) {
+		key: 'resetFileExpiration',
+		value: function resetFileExpiration(key) {
 			return this.s3.copyObjectAsync({
 				Bucket: this.bucket,
 				CopySource: this.bucket + '/' + key,
-				Key: key,
-				Expires: new Date(expiration)
+				Key: key
 			});
 		}
 	}, {
@@ -97,6 +95,7 @@ var FileStorage = function () {
 			}).then(function (data) {
 				return {
 					LastModified: data.LastModified,
+					Expires: data.Expires,
 					ContentLength: data.ContentLength,
 					Body: data.Body
 				};

--- a/dist/util/file-storage.js
+++ b/dist/util/file-storage.js
@@ -69,15 +69,23 @@ var FileStorage = function () {
 		value: function putFile(key, filename, expiration) {
 			var _this = this;
 
-			var expirationTime = new Date(new Date(Date.now()).getTime() + expiration * 1000);
-
 			return openReadStream(filename).then(function (stream) {
 				return _this.s3.putObjectAsync({
 					Bucket: _this.bucket,
 					Key: key,
 					Body: stream,
-					Expires: expirationTime
+					Expires: new Date(expiration)
 				});
+			});
+		}
+	}, {
+		key: 'setFileExpiration',
+		value: function setFileExpiration(key, expiration) {
+			return this.s3.copyObjectAsync({
+				Bucket: this.bucket,
+				CopySource: this.bucket + '/' + key,
+				Key: key,
+				Expires: new Date(expiration)
 			});
 		}
 	}, {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -19,7 +19,7 @@ gulp.task('coverage', () => {
 		.src(['src/**/*.js'])
 		.pipe(istanbul({ instrumenter: isparta.Instrumenter }))
 		.pipe(istanbul.hookRequire());
-})
+});
 
 gulp.task('test', ['lint', 'coverage'], () => {
 	return gulp

--- a/src/util/file-storage.js
+++ b/src/util/file-storage.js
@@ -43,17 +43,24 @@ class FileStorage {
 	}
 
 	putFile(key, filename, expiration) {
-		const expirationTime = new Date(
-			new Date(Date.now()).getTime() + (expiration * 1000));
-
 		return openReadStream(filename)
 			.then(stream => {
 				return this.s3.putObjectAsync({
 					Bucket: this.bucket,
 					Key: key,
 					Body: stream,
-					Expires: expirationTime
+					Expires: new Date(expiration)
 				});
+			});
+	}
+
+	setFileExpiration(key, expiration) {
+		return this.s3
+			.copyObjectAsync({
+				Bucket: this.bucket,
+				CopySource: `${this.bucket}/${key}`,
+				Key: key,
+				Expires: new Date(expiration)
 			});
 	}
 

--- a/src/util/file-storage.js
+++ b/src/util/file-storage.js
@@ -42,25 +42,23 @@ class FileStorage {
 		Promise.promisifyAll(this.s3);
 	}
 
-	putFile(key, filename, expiration) {
+	putFile(key, filename) {
 		return openReadStream(filename)
 			.then(stream => {
 				return this.s3.putObjectAsync({
 					Bucket: this.bucket,
 					Key: key,
-					Body: stream,
-					Expires: new Date(expiration)
+					Body: stream
 				});
 			});
 	}
 
-	setFileExpiration(key, expiration) {
+	resetFileExpiration(key) {
 		return this.s3
 			.copyObjectAsync({
 				Bucket: this.bucket,
 				CopySource: `${this.bucket}/${key}`,
-				Key: key,
-				Expires: new Date(expiration)
+				Key: key
 			});
 	}
 
@@ -73,6 +71,7 @@ class FileStorage {
 			.then(data => {
 				return {
 					LastModified: data.LastModified,
+					Expires: data.Expires,
 					ContentLength: data.ContentLength,
 					Body: data.Body
 				};

--- a/src/util/file-storage.js
+++ b/src/util/file-storage.js
@@ -54,12 +54,17 @@ class FileStorage {
 			});
 	}
 
+	/**
+	 * Resets file expiration. It changes LastModified file property.
+	 * Please PAY ATTENTION, it clears all metadata values, except ContentType
+	 */
 	resetFileExpiration(key) {
 		return this.s3
 			.copyObjectAsync({
 				Bucket: this.bucket,
 				CopySource: `${this.bucket}/${key}`,
-				Key: key
+				Key: key,
+				MetadataDirective: 'REPLACE'
 			});
 	}
 

--- a/tests/util/file-storage.tests.js
+++ b/tests/util/file-storage.tests.js
@@ -62,8 +62,7 @@ describe('File storgage utility', () => {
 			storage
 				.putFile(
 					key,
-					'tests/testAssets/diving-checklist.docx',
-					7)
+					'tests/testAssets/diving-checklist.docx')
 				.then(() => {
 					return s3.getObjectAsync({
 						Bucket: testBucket,
@@ -92,8 +91,7 @@ describe('File storgage utility', () => {
 				.then(() => {
 					return storage.putFile(
 						key,
-						'tests/testAssets/diving-checklist.docx',
-						7);
+						'tests/testAssets/diving-checklist.docx');
 				})
 				.then(() => {
 					return s3.getObjectAsync({
@@ -114,8 +112,7 @@ describe('File storgage utility', () => {
 
 			storage.putFile(
 				key,
-				'tests/testAssets/not-there.pptx',
-				22)
+				'tests/testAssets/not-there.pptx')
 				.then(() => {
 					done('No error was thrown');
 				})


### PR DESCRIPTION
Added method `setFileExpiration` which internally use `s3.copyObject` as a well-known workaround. Fixed implementation of `putFile`