### PR TITLE
Fixed. `Sliding expiration clears ContentType file's property`

### DIFF
--- a/dist/util/file-storage.js
+++ b/dist/util/file-storage.js
@@ -81,16 +81,18 @@ var FileStorage = function () {
 
 		/**
    * Resets file expiration. It changes LastModified file property.
-   * Please PAY ATTENTION, it clears all metadata values, except ContentType
+   * Please PAY ATTENTION, it clears all `Metadata` values and `ContentType`
    */
 
 	}, {
 		key: 'resetFileExpiration',
-		value: function resetFileExpiration(key) {
+		value: function resetFileExpiration(key, contentType, metadata) {
 			return this.s3.copyObjectAsync({
 				Bucket: this.bucket,
 				CopySource: this.bucket + '/' + key,
 				Key: key,
+				ContentType: contentType,
+				Metadata: metadata,
 				MetadataDirective: 'REPLACE'
 			});
 		}

--- a/src/util/file-storage.js
+++ b/src/util/file-storage.js
@@ -56,14 +56,16 @@ class FileStorage {
 
 	/**
 	 * Resets file expiration. It changes LastModified file property.
-	 * Please PAY ATTENTION, it clears all metadata values, except ContentType
+	 * Please PAY ATTENTION, it clears all `Metadata` values and `ContentType`
 	 */
-	resetFileExpiration(key) {
+	resetFileExpiration(key, contentType, metadata) {
 		return this.s3
 			.copyObjectAsync({
 				Bucket: this.bucket,
 				CopySource: `${this.bucket}/${key}`,
 				Key: key,
+				ContentType: contentType,
+				Metadata: metadata,
 				MetadataDirective: 'REPLACE'
 			});
 	}


### PR DESCRIPTION
Added to `resetFileExpiration` parameters in order to have the ability to preserve them during copy into itself